### PR TITLE
630:P1 Improve Performance of Order List Export

### DIFF
--- a/doc/docs/reviews/PR-6-self-review.md
+++ b/doc/docs/reviews/PR-6-self-review.md
@@ -1,0 +1,29 @@
+# Self-Review for PR (Improve Performance of Order List Export)
+
+## What changed and why?
+
+Added `src/tests/base/test_exporter.py` with five integration tests for the `OrderListExporter`:
+
+1. **test_export_completes_for_large_dataset** — Bulk-creates 500 orders and verifies the orders sheet yields exactly 500 data rows without error.
+2. **test_export_memory_bounded** — Measures peak memory via `tracemalloc` during a 500-order export and asserts it stays under 256 MB.
+3. **test_export_positions_sheet_large_dataset** — Validates the positions sheet's chunked iteration (`chunked_iterable`) works correctly for 500 orders.
+4. **test_export_fees_sheet_empty_gracefully** — Confirms the fees sheet handles orders with no fees without crashing.
+5. **test_export_render_csv_does_not_raise** — Runs the full `render()` CSV pipeline end-to-end for 100 orders and checks the output line count.
+
+These tests protect against regressions where large exports could time out, raise MemoryError, or produce incorrect row counts.
+
+## Why is this the right test layer (unit/integration/UI)?
+
+Integration layer. The tests exercise `OrderListExporter` against a real database (via `@pytest.mark.django_db(transaction=True)`) with bulk-created orders, payments, and positions. This is the correct layer because the export logic involves complex ORM queries (subqueries, annotations, iterator-based streaming) that can only be meaningfully tested against a database.
+
+## What could still break / what's not covered?
+
+- The dataset is scaled to 500 orders (not 5,000+) to keep CI runtime reasonable. A production-scale benchmark would require a dedicated performance testing environment.
+- XLSX rendering is not tested for large datasets (CSV only) since XLSX uses `write_only=True` mode which is harder to validate in-memory.
+- The memory threshold (256 MB) is a heuristic; real production limits depend on deployment configuration.
+- Edge cases like orders with subevents, multiple tax rates, or custom questions are not exercised in these performance-focused tests.
+
+## What risks or follow-ups remain?
+
+- A follow-up could add a stress test with 5,000+ orders in a nightly CI job (slower, not suitable for every PR).
+- The `include_payment_amounts` path and multi-event export path are not covered yet.

--- a/src/tests/base/test_exporter.py
+++ b/src/tests/base/test_exporter.py
@@ -1,0 +1,237 @@
+import datetime
+import tracemalloc
+from decimal import Decimal
+
+import pytest
+from django.utils.timezone import now
+from django_scopes import scope, scopes_disabled
+
+from pretix.base.exporters.orderlist import OrderListExporter
+from pretix.base.models import (
+    Event, Item, Order, OrderPosition, Organizer, Quota, Team, User,
+)
+from pretix.base.models.orders import OrderFee, OrderPayment
+
+
+@pytest.fixture(scope='function')
+def organizer():
+    return Organizer.objects.create(name='Big Events', slug='bigevents')
+
+
+@pytest.fixture(scope='function')
+def event(organizer):
+    event = Event.objects.create(
+        organizer=organizer, name='Conference', slug='conf',
+        date_from=datetime.datetime(2025, 6, 15, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        plugins='pretix.plugins.banktransfer',
+        live=True,
+    )
+    organizer.settings.timezone = "UTC"
+    with scope(organizer=organizer):
+        yield event
+
+
+@pytest.fixture
+def team(event):
+    return event.organizer.teams.create(all_events=True, can_view_orders=True)
+
+
+@pytest.fixture
+def user(team):
+    user = User.objects.create_user('exporter@test.com', 'password')
+    team.members.add(user)
+    return user
+
+
+@pytest.fixture
+def item(event):
+    return event.items.create(name='Standard Ticket', default_price=Decimal('50.00'))
+
+
+@pytest.fixture
+def quota(event, item):
+    q = event.quotas.create(name='Standard Quota', size=10000)
+    q.items.add(item)
+    return q
+
+
+def _bulk_create_orders(event, item, count):
+    """Create `count` orders each with one position and one pending payment."""
+    sales_channel = event.organizer.sales_channels.get(identifier="web")
+    orders = []
+    for i in range(count):
+        orders.append(Order(
+            code=f'T{i:05d}',
+            event=event,
+            email=f'buyer{i}@example.com',
+            status=Order.STATUS_PAID,
+            datetime=now(),
+            expires=now() + datetime.timedelta(days=14),
+            total=Decimal('50.00'),
+            locale='en',
+            sales_channel=sales_channel,
+        ))
+    Order.objects.bulk_create(orders)
+    created_orders = list(Order.objects.filter(event=event).order_by('pk'))
+
+    positions = []
+    for idx, order in enumerate(created_orders):
+        positions.append(OrderPosition(
+            order=order,
+            item=item,
+            price=Decimal('50.00'),
+            attendee_name_parts={"full_name": f"Attendee {idx}", "_scheme": "full"},
+            secret=f'secret{idx:08d}',
+            pseudonymization_id=f'PID{idx:06d}',
+            positionid=1,
+        ))
+    OrderPosition.objects.bulk_create(positions)
+
+    payments = []
+    for order in created_orders:
+        payments.append(OrderPayment(
+            order=order,
+            provider='banktransfer',
+            state=OrderPayment.PAYMENT_STATE_CONFIRMED,
+            amount=Decimal('50.00'),
+            payment_date=now(),
+        ))
+    OrderPayment.objects.bulk_create(payments)
+
+    return created_orders
+
+
+@pytest.mark.django_db(transaction=True)
+def test_export_completes_for_large_dataset(event, item, quota, user):
+    """Export of 500+ orders completes without error (scaled-down CI-safe variant)."""
+    order_count = 500
+    with scopes_disabled():
+        _bulk_create_orders(event, item, order_count)
+
+    exporter = OrderListExporter(event, event.organizer)
+    form_data = {
+        '_format': 'default',
+        'paid_only': False,
+        'include_payment_amounts': False,
+        'group_multiple_choice': False,
+    }
+
+    rows = []
+    for line in exporter.iterate_orders(form_data):
+        if hasattr(line, 'total'):
+            continue
+        rows.append(line)
+
+    header = rows[0]
+    data_rows = rows[1:]
+    assert len(data_rows) == order_count, (
+        f"Expected {order_count} data rows, got {len(data_rows)}"
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_export_memory_bounded(event, item, quota, user):
+    """Memory usage during export stays within a reasonable bound (< 256 MB)."""
+    order_count = 500
+    with scopes_disabled():
+        _bulk_create_orders(event, item, order_count)
+
+    exporter = OrderListExporter(event, event.organizer)
+    form_data = {
+        '_format': 'default',
+        'paid_only': False,
+        'include_payment_amounts': False,
+        'group_multiple_choice': False,
+    }
+
+    tracemalloc.start()
+    row_count = 0
+    for line in exporter.iterate_orders(form_data):
+        if hasattr(line, 'total'):
+            continue
+        row_count += 1
+
+    _, peak_mb = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    peak_mb = peak_mb / (1024 * 1024)
+
+    assert peak_mb < 256, (
+        f"Peak memory {peak_mb:.1f} MB exceeds 256 MB threshold"
+    )
+    assert row_count > 0
+
+
+@pytest.mark.django_db(transaction=True)
+def test_export_positions_sheet_large_dataset(event, item, quota, user):
+    """Positions sheet export handles large datasets via chunked iteration."""
+    order_count = 500
+    with scopes_disabled():
+        _bulk_create_orders(event, item, order_count)
+
+    exporter = OrderListExporter(event, event.organizer)
+    form_data = {
+        '_format': 'default',
+        'paid_only': False,
+        'include_payment_amounts': False,
+        'group_multiple_choice': False,
+    }
+
+    rows = []
+    for line in exporter.iterate_positions(form_data):
+        if hasattr(line, 'total'):
+            continue
+        rows.append(line)
+
+    header = rows[0]
+    data_rows = rows[1:]
+    assert len(data_rows) == order_count, (
+        f"Expected {order_count} position rows, got {len(data_rows)}"
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_export_fees_sheet_empty_gracefully(event, item, quota, user):
+    """Fees sheet export handles case where there are orders but no fees."""
+    order_count = 50
+    with scopes_disabled():
+        _bulk_create_orders(event, item, order_count)
+
+    exporter = OrderListExporter(event, event.organizer)
+    form_data = {
+        '_format': 'default',
+        'paid_only': False,
+        'include_payment_amounts': False,
+        'group_multiple_choice': False,
+    }
+
+    rows = []
+    for line in exporter.iterate_fees(form_data):
+        if hasattr(line, 'total'):
+            continue
+        rows.append(line)
+
+    header = rows[0]
+    data_rows = rows[1:]
+    assert len(data_rows) == 0
+
+
+@pytest.mark.django_db(transaction=True)
+def test_export_render_csv_does_not_raise(event, item, quota, user):
+    """Full CSV render pipeline completes without raising for a non-trivial dataset."""
+    order_count = 100
+    with scopes_disabled():
+        _bulk_create_orders(event, item, order_count)
+
+    exporter = OrderListExporter(event, event.organizer)
+    form_data = {
+        '_format': 'orders:default',
+        'paid_only': False,
+        'include_payment_amounts': False,
+        'group_multiple_choice': False,
+    }
+
+    filename, content_type, data = exporter.render(form_data)
+    assert filename.endswith('.csv')
+    assert data is not None
+    lines = data.decode('utf-8').strip().split('\n')
+    assert len(lines) == order_count + 1  # header + data rows


### PR DESCRIPTION
Closes #6

## Summary
Added `src/tests/base/test_exporter.py` with 5 integration tests for `OrderListExporter` that validate large-dataset export (500 orders) completes correctly, stays memory-bounded (< 256 MB), and handles all three sheets (orders, positions, fees).

## How to run relevant tests
```bash
pytest src/tests/base/test_exporter.py -v
```

## Evidence
- **Behavior now protected**: Large exports completing without MemoryError or incorrect row counts; chunked position iteration; graceful handling of empty fees.
- **What would regress before**: No tests existed for export performance or correctness at scale. A query regression or memory leak in OrderListExporter would go undetected.

## Self-review
See `doc/docs/reviews/PR-6-self-review.md` included in this PR.