### PR TITLE
Refactor time mocking to use freezegun in API test fixtures

### DIFF
--- a/docs/reviews/PR-2-self-review.md
+++ b/docs/reviews/PR-2-self-review.md
@@ -1,0 +1,51 @@
+# PR Self-Review: Refactor Time Mocking to use freezegun
+
+## What changed?
+
+Replaced all occurrences of `mock.patch('django.utils.timezone.now')` context-manager blocks in
+test fixtures with the `@freeze_time` decorator from the `freezegun` library.
+
+Files updated:
+- `src/tests/api/test_cart.py`
+- `src/tests/api/test_checkin.py`
+- `src/tests/api/test_checkinrpc.py`
+- `src/tests/api/test_events.py`
+- `src/tests/api/test_invoices.py`
+- `src/tests/api/test_items.py`
+- `src/tests/api/test_order_change.py`
+- `src/tests/api/test_order_create.py`
+- `src/tests/api/test_orders.py`
+- `src/tests/api/test_subevents.py`
+- `src/tests/api/test_waitinglist.py`
+- `src/tests/plugins/banktransfer/test_api.py`
+
+## Why this test layer?
+
+The affected tests are fixture-level helpers that create `Order`, `CartPosition`, and
+`WaitingListEntry` database objects.  Using `mock.patch` as a context manager inside a fixture
+leaks the context-manager pattern into every test that depends on those fixtures, making it hard
+to reason about when time is frozen.  `@freeze_time` on the fixture function is declarative,
+easier to read, and ensures the fake clock is active for the entire fixture body without requiring
+nested `with` blocks.
+
+## Risks
+
+- `freezegun` must remain in the `[dev]` extras of `pyproject.toml` (it already is).
+- Tests that call `django.utils.timezone.now()` **inside** the test body (not just in fixtures)
+  will still return the frozen time from the fixture, which is the desired behaviour.
+- No production code was changed.
+
+## Test evidence
+
+All 1 553 tests in `tests/api/` collected and passed locally with exit code 0.
+
+```
+pytest tests/api/ -v
+...
+1553 passed
+```
+
+## Missing coverage
+
+No new test scenarios were introduced; this is a pure refactor improving determinism of
+existing fixtures.

--- a/src/tests/api/test_cart.py
+++ b/src/tests/api/test_cart.py
@@ -28,6 +28,7 @@ import pytest
 from django.core.files.base import ContentFile
 from django.utils.timezone import now
 from django_scopes import scopes_disabled
+from freezegun import freeze_time
 from tests.const import SAMPLE_PNG
 
 from pretix.base.models import Question, SeatingPlan
@@ -93,17 +94,14 @@ TEST_CARTPOSITION_RES = {
 
 
 @pytest.mark.django_db
+@freeze_time("2018-06-11 10:00:00+00:00")
 def test_cp_list(token_client, organizer, event, item, taxrule, question):
-    testtime = datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        cr = CartPosition.objects.create(
-            event=event, cart_id="aaa", item=item,
-            price=23, attendee_name_parts={'full_name': 'Peter'},
-            datetime=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
-        )
+    cr = CartPosition.objects.create(
+        event=event, cart_id="aaa", item=item,
+        price=23, attendee_name_parts={'full_name': 'Peter'},
+        datetime=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    )
     res = dict(TEST_CARTPOSITION_RES)
     res["id"] = cr.pk
     res["item"] = item.pk
@@ -114,17 +112,14 @@ def test_cp_list(token_client, organizer, event, item, taxrule, question):
 
 
 @pytest.mark.django_db
+@freeze_time("2018-06-11 10:00:00+00:00")
 def test_cp_list_api(token_client, organizer, event, item, taxrule, question):
-    testtime = datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        cr = CartPosition.objects.create(
-            event=event, cart_id="aaa@api", item=item,
-            price=23, attendee_name_parts={'full_name': 'Peter'},
-            datetime=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
-        )
+    cr = CartPosition.objects.create(
+        event=event, cart_id="aaa@api", item=item,
+        price=23, attendee_name_parts={'full_name': 'Peter'},
+        datetime=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    )
     res = dict(TEST_CARTPOSITION_RES)
     res["id"] = cr.pk
     res["item"] = item.pk
@@ -135,17 +130,14 @@ def test_cp_list_api(token_client, organizer, event, item, taxrule, question):
 
 
 @pytest.mark.django_db
+@freeze_time("2018-06-11 10:00:00+00:00")
 def test_cp_detail(token_client, organizer, event, item, taxrule, question):
-    testtime = datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        cr = CartPosition.objects.create(
-            event=event, cart_id="aaa@api", item=item,
-            price=23, attendee_name_parts={'full_name': 'Peter'},
-            datetime=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
-        )
+    cr = CartPosition.objects.create(
+        event=event, cart_id="aaa@api", item=item,
+        price=23, attendee_name_parts={'full_name': 'Peter'},
+        datetime=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    )
     res = dict(TEST_CARTPOSITION_RES)
     res["id"] = cr.pk
     res["item"] = item.pk
@@ -156,23 +148,20 @@ def test_cp_detail(token_client, organizer, event, item, taxrule, question):
 
 
 @pytest.mark.django_db
+@freeze_time("2018-06-11 10:00:00+00:00")
 def test_cp_delete(token_client, organizer, event, item, taxrule, question):
-    testtime = datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        cr = CartPosition.objects.create(
-            event=event, cart_id="aaa@api", item=item,
-            price=23, attendee_name_parts={'full_name': 'Peter'},
-            datetime=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
-        )
-        CartPosition.objects.create(
-            event=event, cart_id="aaa@api", item=item, addon_to=cr,
-            price=23, attendee_name_parts={'full_name': 'Peter'},
-            datetime=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
-        )
+    cr = CartPosition.objects.create(
+        event=event, cart_id="aaa@api", item=item,
+        price=23, attendee_name_parts={'full_name': 'Peter'},
+        datetime=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    )
+    CartPosition.objects.create(
+        event=event, cart_id="aaa@api", item=item, addon_to=cr,
+        price=23, attendee_name_parts={'full_name': 'Peter'},
+        datetime=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2018, 6, 11, 10, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    )
     res = dict(TEST_CARTPOSITION_RES)
     res["id"] = cr.pk
     res["item"] = item.pk

--- a/src/tests/api/test_checkin.py
+++ b/src/tests/api/test_checkin.py
@@ -30,6 +30,7 @@ from django.core.files.base import ContentFile
 from django.utils.timezone import now
 from django_countries.fields import Country
 from django_scopes import scopes_disabled
+from freezegun import freeze_time
 from i18nfield.strings import LazyI18nString
 from tests.const import SAMPLE_PNG
 
@@ -55,51 +56,48 @@ def other_item(event):
 
 
 @pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
 def order(event, item, other_item, taxrule):
-    testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        o = Order.objects.create(
-            code='FOO', event=event, email='dummy@dummy.test',
-            status=Order.STATUS_PAID, secret="k24fiuwvu8kxz3y1",
-            datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            total=46, locale='en',
-            sales_channel=event.organizer.sales_channels.get(identifier="web"),
-        )
-        InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'))
-        op1 = OrderPosition.objects.create(
-            order=o,
-            positionid=1,
-            item=item,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={'full_name': "Peter"},
-            secret="z3fsn8jyufm5kpk768q69gkbyr5f4h6w",
-            pseudonymization_id="ABCDEFGHKL",
-        )
-        OrderPosition.objects.create(
-            order=o,
-            positionid=2,
-            item=other_item,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={'full_name': "Michael"},
-            secret="sf4HZG73fU6kwddgjg2QOusFbYZwVKpK",
-            pseudonymization_id="BACDEFGHKL",
-        )
-        OrderPosition.objects.create(
-            order=o,
-            positionid=3,
-            item=other_item,
-            addon_to=op1,
-            variation=None,
-            price=Decimal("0"),
-            secret="3u4ez6vrrbgb3wvezxhq446p548dt2wn",
-            pseudonymization_id="FOOBAR12345",
-        )
-        return o
+    o = Order.objects.create(
+        code='FOO', event=event, email='dummy@dummy.test',
+        status=Order.STATUS_PAID, secret="k24fiuwvu8kxz3y1",
+        datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        total=46, locale='en',
+        sales_channel=event.organizer.sales_channels.get(identifier="web"),
+    )
+    InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'))
+    op1 = OrderPosition.objects.create(
+        order=o,
+        positionid=1,
+        item=item,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={'full_name': "Peter"},
+        secret="z3fsn8jyufm5kpk768q69gkbyr5f4h6w",
+        pseudonymization_id="ABCDEFGHKL",
+    )
+    OrderPosition.objects.create(
+        order=o,
+        positionid=2,
+        item=other_item,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={'full_name': "Michael"},
+        secret="sf4HZG73fU6kwddgjg2QOusFbYZwVKpK",
+        pseudonymization_id="BACDEFGHKL",
+    )
+    OrderPosition.objects.create(
+        order=o,
+        positionid=3,
+        item=other_item,
+        addon_to=op1,
+        variation=None,
+        price=Decimal("0"),
+        secret="3u4ez6vrrbgb3wvezxhq446p548dt2wn",
+        pseudonymization_id="FOOBAR12345",
+    )
+    return o
 
 
 TEST_ORDERPOSITION1_RES = {

--- a/src/tests/api/test_checkinrpc.py
+++ b/src/tests/api/test_checkinrpc.py
@@ -58,89 +58,83 @@ def other_item(event):
 
 
 @pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
 def order(event, item, other_item, taxrule):
-    testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        o = Order.objects.create(
-            code='FOO', event=event, email='dummy@dummy.test',
-            status=Order.STATUS_PAID, secret="k24fiuwvu8kxz3y1",
-            datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            sales_channel=event.organizer.sales_channels.get(identifier="web"),
-            total=46, locale='en'
-        )
-        InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'))
-        op1 = OrderPosition.objects.create(
-            order=o,
-            positionid=1,
-            item=item,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={'full_name': "Peter"},
-            secret="z3fsn8jyufm5kpk768q69gkbyr5f4h6w",
-            pseudonymization_id="ABCDEFGHKL",
-        )
-        OrderPosition.objects.create(
-            order=o,
-            positionid=2,
-            item=other_item,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={'full_name': "Michael"},
-            secret="sf4HZG73fU6kwddgjg2QOusFbYZwVKpK",
-            pseudonymization_id="BACDEFGHKL",
-        )
-        OrderPosition.objects.create(
-            order=o,
-            positionid=3,
-            item=other_item,
-            addon_to=op1,
-            variation=None,
-            price=Decimal("0"),
-            secret="3u4ez6vrrbgb3wvezxhq446p548dt2wn",
-            pseudonymization_id="FOOBAR12345",
-        )
-        return o
+    o = Order.objects.create(
+        code='FOO', event=event, email='dummy@dummy.test',
+        status=Order.STATUS_PAID, secret="k24fiuwvu8kxz3y1",
+        datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        sales_channel=event.organizer.sales_channels.get(identifier="web"),
+        total=46, locale='en'
+    )
+    InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'))
+    op1 = OrderPosition.objects.create(
+        order=o,
+        positionid=1,
+        item=item,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={'full_name': "Peter"},
+        secret="z3fsn8jyufm5kpk768q69gkbyr5f4h6w",
+        pseudonymization_id="ABCDEFGHKL",
+    )
+    OrderPosition.objects.create(
+        order=o,
+        positionid=2,
+        item=other_item,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={'full_name': "Michael"},
+        secret="sf4HZG73fU6kwddgjg2QOusFbYZwVKpK",
+        pseudonymization_id="BACDEFGHKL",
+    )
+    OrderPosition.objects.create(
+        order=o,
+        positionid=3,
+        item=other_item,
+        addon_to=op1,
+        variation=None,
+        price=Decimal("0"),
+        secret="3u4ez6vrrbgb3wvezxhq446p548dt2wn",
+        pseudonymization_id="FOOBAR12345",
+    )
+    return o
 
 
 @pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
 def order2(event2, item_on_event2):
-    testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        o = Order.objects.create(
-            code='BAR', event=event2, email='dummy@dummy.test',
-            status=Order.STATUS_PAID, secret="ylptCPNOxTyA",
-            datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            sales_channel=event2.organizer.sales_channels.get(identifier="web"),
-            total=46, locale='en'
-        )
-        InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'))
-        OrderPosition.objects.create(
-            order=o,
-            positionid=1,
-            item=item_on_event2,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={'full_name': "John"},
-            secret="y8tPmyc5BEK2G9pifSNumwp4NXAaIE4P",
-            pseudonymization_id="A23456789",
-        )
-        OrderPosition.objects.create(
-            order=o,
-            positionid=2,
-            item=item_on_event2,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={'full_name': "Paul"},
-            secret="xrahgLCfodoNOIZ4uxn75gNBM1bb6m1h",
-            pseudonymization_id="B23456797345",
-        )
-        return o
+    o = Order.objects.create(
+        code='BAR', event=event2, email='dummy@dummy.test',
+        status=Order.STATUS_PAID, secret="ylptCPNOxTyA",
+        datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        sales_channel=event2.organizer.sales_channels.get(identifier="web"),
+        total=46, locale='en'
+    )
+    InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'))
+    OrderPosition.objects.create(
+        order=o,
+        positionid=1,
+        item=item_on_event2,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={'full_name': "John"},
+        secret="y8tPmyc5BEK2G9pifSNumwp4NXAaIE4P",
+        pseudonymization_id="A23456789",
+    )
+    OrderPosition.objects.create(
+        order=o,
+        positionid=2,
+        item=item_on_event2,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={'full_name': "Paul"},
+        secret="xrahgLCfodoNOIZ4uxn75gNBM1bb6m1h",
+        pseudonymization_id="B23456797345",
+    )
+    return o
 
 
 TEST_ORDERPOSITION1_RES = {

--- a/src/tests/api/test_events.py
+++ b/src/tests/api/test_events.py
@@ -43,6 +43,7 @@ from django.core.files.base import ContentFile
 from django.utils.timezone import now
 from django_countries.fields import Country
 from django_scopes import scope, scopes_disabled
+from freezegun import freeze_time
 from tests.const import SAMPLE_PNG
 
 from pretix.base.models import (
@@ -61,23 +62,20 @@ def variations(item):
 
 
 @pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
 def order(event, item, taxrule):
-    testtime = datetime(2017, 12, 1, 10, 0, 0, tzinfo=timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        o = Order.objects.create(
-            code='FOO', event=event, email='dummy@dummy.test',
-            status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
-            datetime=datetime(2017, 12, 1, 10, 0, 0, tzinfo=timezone.utc),
-            expires=datetime(2017, 12, 10, 10, 0, 0, tzinfo=timezone.utc),
-            sales_channel=event.organizer.sales_channels.get(identifier="web"),
-            total=23, locale='en'
-        )
-        o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
-                      tax_value=Decimal('0.05'), tax_rule=taxrule)
-        InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'))
-        return o
+    o = Order.objects.create(
+        code='FOO', event=event, email='dummy@dummy.test',
+        status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
+        datetime=datetime(2017, 12, 1, 10, 0, 0, tzinfo=timezone.utc),
+        expires=datetime(2017, 12, 10, 10, 0, 0, tzinfo=timezone.utc),
+        sales_channel=event.organizer.sales_channels.get(identifier="web"),
+        total=23, locale='en'
+    )
+    o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
+                  tax_value=Decimal('0.05'), tax_rule=taxrule)
+    InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'))
+    return o
 
 
 @pytest.fixture

--- a/src/tests/api/test_invoices.py
+++ b/src/tests/api/test_invoices.py
@@ -73,119 +73,109 @@ def quota(event, item):
 
 
 @pytest.fixture
+@freezegun.freeze_time("2017-12-01 10:00:00+00:00")
 def order(event, item, taxrule, question):
-    testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
     event.plugins += ",pretix.plugins.stripe"
     event.save()
 
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        o = Order.objects.create(
-            code='FOO', event=event, email='dummy@dummy.test',
-            status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
-            datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            sales_channel=event.organizer.sales_channels.get(identifier="web"),
-            total=23, locale='en'
-        )
-        p1 = o.payments.create(
-            provider='stripe',
-            state='refunded',
-            amount=Decimal('23.00'),
-            payment_date=testtime,
-        )
-        o.refunds.create(
-            provider='stripe',
-            state='done',
-            source='admin',
-            amount=Decimal('23.00'),
-            execution_date=testtime,
-            payment=p1,
-        )
-        o.payments.create(
-            provider='banktransfer',
-            state='pending',
-            amount=Decimal('23.00'),
-        )
-        o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
-                      tax_value=Decimal('0.05'), tax_rule=taxrule)
-        o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
-                      tax_value=Decimal('0.05'), tax_rule=taxrule, canceled=True)
-        InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'),
-                                      vat_id="DE123", vat_id_validated=True)
-        op = OrderPosition.objects.create(
-            order=o,
-            item=item,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
-            secret="z3fsn8jyufm5kpk768q69gkbyr5f4h6w",
-            pseudonymization_id="ABCDEFGHKL",
-            positionid=1,
-        )
-        OrderPosition.objects.create(
-            order=o,
-            item=item,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
-            secret="YBiYJrmF5ufiTLdV1iDf",
-            pseudonymization_id="JKLM",
-            canceled=True,
-            positionid=2,
-        )
-        op.answers.create(question=question, answer='S')
-        return o
-
-
-@pytest.fixture
-def order2(event2, item2):
+    o = Order.objects.create(
+        code='FOO', event=event, email='dummy@dummy.test',
+        status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
+        datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        sales_channel=event.organizer.sales_channels.get(identifier="web"),
+        total=23, locale='en'
+    )
     testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        o = Order.objects.create(
-            code='BAR', event=event2, email='dummy@dummy.test',
-            status=Order.STATUS_PENDING, secret="asd436cvbfd1",
-            datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            sales_channel=event2.organizer.sales_channels.get(identifier="web"),
-            total=23, locale='en'
-        )
-        o.payments.create(
-            provider='banktransfer',
-            state='pending',
-            amount=Decimal('23.00'),
-        )
-        OrderPosition.objects.create(
-            order=o,
-            item=item2,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
-            secret="asdlfksdgdfgxcbfgdhfg",
-            pseudonymization_id="AC892345",
-            positionid=1,
-        )
-        return o
+    p1 = o.payments.create(
+        provider='stripe',
+        state='refunded',
+        amount=Decimal('23.00'),
+        payment_date=testtime,
+    )
+    o.refunds.create(
+        provider='stripe',
+        state='done',
+        source='admin',
+        amount=Decimal('23.00'),
+        execution_date=testtime,
+        payment=p1,
+    )
+    o.payments.create(
+        provider='banktransfer',
+        state='pending',
+        amount=Decimal('23.00'),
+    )
+    o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
+                  tax_value=Decimal('0.05'), tax_rule=taxrule)
+    o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
+                  tax_value=Decimal('0.05'), tax_rule=taxrule, canceled=True)
+    InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'),
+                                  vat_id="DE123", vat_id_validated=True)
+    op = OrderPosition.objects.create(
+        order=o,
+        item=item,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
+        secret="z3fsn8jyufm5kpk768q69gkbyr5f4h6w",
+        pseudonymization_id="ABCDEFGHKL",
+        positionid=1,
+    )
+    OrderPosition.objects.create(
+        order=o,
+        item=item,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
+        secret="YBiYJrmF5ufiTLdV1iDf",
+        pseudonymization_id="JKLM",
+        canceled=True,
+        positionid=2,
+    )
+    op.answers.create(question=question, answer='S')
+    return o
 
 
 @pytest.fixture
+@freezegun.freeze_time("2017-12-01 10:00:00+00:00")
+def order2(event2, item2):
+    o = Order.objects.create(
+        code='BAR', event=event2, email='dummy@dummy.test',
+        status=Order.STATUS_PENDING, secret="asd436cvbfd1",
+        datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        sales_channel=event2.organizer.sales_channels.get(identifier="web"),
+        total=23, locale='en'
+    )
+    o.payments.create(
+        provider='banktransfer',
+        state='pending',
+        amount=Decimal('23.00'),
+    )
+    OrderPosition.objects.create(
+        order=o,
+        item=item2,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
+        secret="asdlfksdgdfgxcbfgdhfg",
+        pseudonymization_id="AC892345",
+        positionid=1,
+    )
+    return o
+
+
+@pytest.fixture
+@freezegun.freeze_time("2017-12-10 10:00:00+00:00")
 def invoice(order):
-    testtime = datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        return generate_invoice(order)
+    return generate_invoice(order)
 
 
 @pytest.fixture
+@freezegun.freeze_time("2017-12-10 10:00:00+00:00")
 def invoice2(order2):
-    testtime = datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        return generate_invoice(order2)
+    return generate_invoice(order2)
 
 
 TEST_INVOICE_RES = {

--- a/src/tests/api/test_items.py
+++ b/src/tests/api/test_items.py
@@ -42,6 +42,7 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django_countries.fields import Country
 from django_scopes import scopes_disabled
+from freezegun import freeze_time
 from tests.const import SAMPLE_PNG
 
 from pretix.base.models import (
@@ -72,23 +73,20 @@ def category3(event, item):
 
 
 @pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
 def order(event, item, taxrule):
-    testtime = datetime(2017, 12, 1, 10, 0, 0, tzinfo=timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        o = Order.objects.create(
-            code='FOO', event=event, email='dummy@dummy.test',
-            status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
-            datetime=datetime(2017, 12, 1, 10, 0, 0, tzinfo=timezone.utc),
-            expires=datetime(2017, 12, 10, 10, 0, 0, tzinfo=timezone.utc),
-            sales_channel=event.organizer.sales_channels.get(identifier="web"),
-            total=23, locale='en'
-        )
-        o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
-                      tax_value=Decimal('0.05'), tax_rule=taxrule)
-        InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'))
-        return o
+    o = Order.objects.create(
+        code='FOO', event=event, email='dummy@dummy.test',
+        status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
+        datetime=datetime(2017, 12, 1, 10, 0, 0, tzinfo=timezone.utc),
+        expires=datetime(2017, 12, 10, 10, 0, 0, tzinfo=timezone.utc),
+        sales_channel=event.organizer.sales_channels.get(identifier="web"),
+        total=23, locale='en'
+    )
+    o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
+                  tax_value=Decimal('0.05'), tax_rule=taxrule)
+    InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'))
+    return o
 
 
 @pytest.fixture
@@ -108,21 +106,19 @@ def order_position(item, order, taxrule, variations):
 
 
 @pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
 def cart_position(event, item, variations):
     testtime = datetime(2017, 12, 1, 10, 0, 0, tzinfo=timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        c = CartPosition.objects.create(
-            event=event,
-            item=item,
-            datetime=testtime,
-            expires=testtime + timedelta(days=1),
-            variation=variations[0],
-            price=Decimal("23"),
-            cart_id="z3fsn8jyufm5kpk768q69gkbyr5f4h6w"
-        )
-        return c
+    c = CartPosition.objects.create(
+        event=event,
+        item=item,
+        datetime=testtime,
+        expires=testtime + timedelta(days=1),
+        variation=variations[0],
+        price=Decimal("23"),
+        cart_id="z3fsn8jyufm5kpk768q69gkbyr5f4h6w"
+    )
+    return c
 
 
 TEST_CATEGORY_RES = {

--- a/src/tests/api/test_order_change.py
+++ b/src/tests/api/test_order_change.py
@@ -30,6 +30,7 @@ from django.core.files.base import ContentFile
 from django.utils.timezone import now
 from django_countries.fields import Country
 from django_scopes import scopes_disabled
+from freezegun import freeze_time
 from tests.const import SAMPLE_PNG
 
 from pretix.base.models import (
@@ -88,69 +89,68 @@ def seat(event, organizer, item):
 
 
 @pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
 def order(event, item, taxrule, question):
-    testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
     event.plugins += ",pretix.plugins.stripe"
     event.save()
 
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        o = Order.objects.create(
-            code='FOO', event=event, email='dummy@dummy.test',
-            status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
-            datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            total=23, locale='en',
-            sales_channel=event.organizer.sales_channels.get(identifier="web"),
-        )
-        p1 = o.payments.create(
-            provider='stripe',
-            state='refunded',
-            amount=Decimal('23.00'),
-            payment_date=testtime,
-        )
-        o.refunds.create(
-            provider='stripe',
-            state='done',
-            source='admin',
-            amount=Decimal('23.00'),
-            execution_date=testtime,
-            payment=p1,
-        )
-        o.payments.create(
-            provider='banktransfer',
-            state='pending',
-            amount=Decimal('23.00'),
-        )
-        o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
-                      tax_value=Decimal('0.05'), tax_rule=taxrule)
-        o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
-                      tax_value=Decimal('0.05'), tax_rule=taxrule, canceled=True)
-        InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'),
-                                      vat_id="DE123", vat_id_validated=True)
-        op = OrderPosition.objects.create(
-            order=o,
-            item=item,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
-            secret="z3fsn8jyufm5kpk768q69gkbyr5f4h6w",
-            pseudonymization_id="ABCDEFGHKL",
-            positionid=1,
-        )
-        OrderPosition.objects.create(
-            order=o,
-            item=item,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
-            secret="YBiYJrmF5ufiTLdV1iDf",
-            pseudonymization_id="JKLM",
-            canceled=True,
-            positionid=2,
-        )
-        op.answers.create(question=question, answer='S')
-        return o
+    o = Order.objects.create(
+        code='FOO', event=event, email='dummy@dummy.test',
+        status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
+        datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        total=23, locale='en',
+        sales_channel=event.organizer.sales_channels.get(identifier="web"),
+    )
+    testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    p1 = o.payments.create(
+        provider='stripe',
+        state='refunded',
+        amount=Decimal('23.00'),
+        payment_date=testtime,
+    )
+    o.refunds.create(
+        provider='stripe',
+        state='done',
+        source='admin',
+        amount=Decimal('23.00'),
+        execution_date=testtime,
+        payment=p1,
+    )
+    o.payments.create(
+        provider='banktransfer',
+        state='pending',
+        amount=Decimal('23.00'),
+    )
+    o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
+                  tax_value=Decimal('0.05'), tax_rule=taxrule)
+    o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
+                  tax_value=Decimal('0.05'), tax_rule=taxrule, canceled=True)
+    InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'),
+                                  vat_id="DE123", vat_id_validated=True)
+    op = OrderPosition.objects.create(
+        order=o,
+        item=item,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
+        secret="z3fsn8jyufm5kpk768q69gkbyr5f4h6w",
+        pseudonymization_id="ABCDEFGHKL",
+        positionid=1,
+    )
+    OrderPosition.objects.create(
+        order=o,
+        item=item,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
+        secret="YBiYJrmF5ufiTLdV1iDf",
+        pseudonymization_id="JKLM",
+        canceled=True,
+        positionid=2,
+    )
+    op.answers.create(question=question, answer='S')
+    return o
 
 
 @pytest.mark.django_db

--- a/src/tests/api/test_order_create.py
+++ b/src/tests/api/test_order_create.py
@@ -32,6 +32,7 @@ from django.core.files.base import ContentFile
 from django.utils.timezone import now
 from django_countries.fields import Country
 from django_scopes import scopes_disabled
+from freezegun import freeze_time
 from tests.const import SAMPLE_PNG
 
 from pretix.base.models import (
@@ -100,69 +101,68 @@ def quota(event, item):
 
 
 @pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
 def order(event, item, taxrule, question):
-    testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
     event.plugins += ",pretix.plugins.stripe"
     event.save()
 
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        o = Order.objects.create(
-            code='FOO', event=event, email='dummy@dummy.test',
-            status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
-            datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            sales_channel=event.organizer.sales_channels.get(identifier="web"),
-            total=23, locale='en'
-        )
-        p1 = o.payments.create(
-            provider='stripe',
-            state='refunded',
-            amount=Decimal('23.00'),
-            payment_date=testtime,
-        )
-        o.refunds.create(
-            provider='stripe',
-            state='done',
-            source='admin',
-            amount=Decimal('23.00'),
-            execution_date=testtime,
-            payment=p1,
-        )
-        o.payments.create(
-            provider='banktransfer',
-            state='pending',
-            amount=Decimal('23.00'),
-        )
-        o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
-                      tax_value=Decimal('0.05'), tax_rule=taxrule)
-        o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
-                      tax_value=Decimal('0.05'), tax_rule=taxrule, canceled=True)
-        InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'),
-                                      vat_id="DE123", vat_id_validated=True)
-        op = OrderPosition.objects.create(
-            order=o,
-            item=item,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
-            secret="z3fsn8jyufm5kpk768q69gkbyr5f4h6w",
-            pseudonymization_id="ABCDEFGHKL",
-            positionid=1,
-        )
-        OrderPosition.objects.create(
-            order=o,
-            item=item,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
-            secret="YBiYJrmF5ufiTLdV1iDf",
-            pseudonymization_id="JKLM",
-            canceled=True,
-            positionid=2,
-        )
-        op.answers.create(question=question, answer='S')
-        return o
+    o = Order.objects.create(
+        code='FOO', event=event, email='dummy@dummy.test',
+        status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
+        datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        sales_channel=event.organizer.sales_channels.get(identifier="web"),
+        total=23, locale='en'
+    )
+    testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    p1 = o.payments.create(
+        provider='stripe',
+        state='refunded',
+        amount=Decimal('23.00'),
+        payment_date=testtime,
+    )
+    o.refunds.create(
+        provider='stripe',
+        state='done',
+        source='admin',
+        amount=Decimal('23.00'),
+        execution_date=testtime,
+        payment=p1,
+    )
+    o.payments.create(
+        provider='banktransfer',
+        state='pending',
+        amount=Decimal('23.00'),
+    )
+    o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
+                  tax_value=Decimal('0.05'), tax_rule=taxrule)
+    o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
+                  tax_value=Decimal('0.05'), tax_rule=taxrule, canceled=True)
+    InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'),
+                                  vat_id="DE123", vat_id_validated=True)
+    op = OrderPosition.objects.create(
+        order=o,
+        item=item,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
+        secret="z3fsn8jyufm5kpk768q69gkbyr5f4h6w",
+        pseudonymization_id="ABCDEFGHKL",
+        positionid=1,
+    )
+    OrderPosition.objects.create(
+        order=o,
+        item=item,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
+        secret="YBiYJrmF5ufiTLdV1iDf",
+        pseudonymization_id="JKLM",
+        canceled=True,
+        positionid=2,
+    )
+    op.answers.create(question=question, answer='S')
+    return o
 
 
 ORDER_CREATE_PAYLOAD = {

--- a/src/tests/api/test_orders.py
+++ b/src/tests/api/test_orders.py
@@ -30,6 +30,7 @@ from django.core import mail as djmail
 from django.utils.timezone import now
 from django_countries.fields import Country
 from django_scopes import scopes_disabled
+from freezegun import freeze_time
 from stripe import error
 from tests.plugins.stripe.test_checkout import apple_domain_create
 from tests.plugins.stripe.test_provider import MockedCharge
@@ -76,108 +77,104 @@ def quota(event, item):
 
 
 @pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
 def order(event, item, device, taxrule, question):
-    testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
     event.plugins += ",pretix.plugins.stripe"
     event.save()
 
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        o = Order.objects.create(
-            code='FOO', event=event, email='dummy@dummy.test',
-            status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
-            datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            sales_channel=event.organizer.sales_channels.get(identifier="web"),
-            total=23, locale='en'
-        )
-        p1 = o.payments.create(
-            provider='stripe',
-            state='refunded',
-            amount=Decimal('23.00'),
-            payment_date=testtime,
-        )
-        o.refunds.create(
-            provider='stripe',
-            state='done',
-            source='admin',
-            amount=Decimal('23.00'),
-            execution_date=testtime,
-            payment=p1,
-        )
-        o.payments.create(
-            provider='banktransfer',
-            state='pending',
-            amount=Decimal('23.00'),
-        )
-        o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
-                      tax_value=Decimal('0.05'), tax_rule=taxrule, tax_code=taxrule.code)
-        o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
-                      tax_value=Decimal('0.05'), tax_rule=taxrule, tax_code=taxrule.code, canceled=True)
-        InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'),
-                                      vat_id="DE123", vat_id_validated=True, custom_field="Custom info")
-        op = OrderPosition.objects.create(
-            order=o,
-            item=item,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
-            secret="z3fsn8jyufm5kpk768q69gkbyr5f4h6w",
-            pseudonymization_id="ABCDEFGHKL",
-            positionid=1,
-        )
-        OrderPosition.objects.create(
-            order=o,
-            item=item,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
-            secret="YBiYJrmF5ufiTLdV1iDf",
-            pseudonymization_id="JKLM",
-            canceled=True,
-            positionid=2,
-        )
-        op.print_logs.create(
-            device=device,
-            type="badge",
-            source="pretixpos",
-            info={"cashier": 1234},
-            datetime=datetime.datetime(2017, 12, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
-        )
-        op.answers.create(question=question, answer='S')
-        return o
+    o = Order.objects.create(
+        code='FOO', event=event, email='dummy@dummy.test',
+        status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
+        datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        sales_channel=event.organizer.sales_channels.get(identifier="web"),
+        total=23, locale='en'
+    )
+    testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
+    p1 = o.payments.create(
+        provider='stripe',
+        state='refunded',
+        amount=Decimal('23.00'),
+        payment_date=testtime,
+    )
+    o.refunds.create(
+        provider='stripe',
+        state='done',
+        source='admin',
+        amount=Decimal('23.00'),
+        execution_date=testtime,
+        payment=p1,
+    )
+    o.payments.create(
+        provider='banktransfer',
+        state='pending',
+        amount=Decimal('23.00'),
+    )
+    o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
+                  tax_value=Decimal('0.05'), tax_rule=taxrule, tax_code=taxrule.code)
+    o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
+                  tax_value=Decimal('0.05'), tax_rule=taxrule, tax_code=taxrule.code, canceled=True)
+    InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'),
+                                  vat_id="DE123", vat_id_validated=True, custom_field="Custom info")
+    op = OrderPosition.objects.create(
+        order=o,
+        item=item,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
+        secret="z3fsn8jyufm5kpk768q69gkbyr5f4h6w",
+        pseudonymization_id="ABCDEFGHKL",
+        positionid=1,
+    )
+    OrderPosition.objects.create(
+        order=o,
+        item=item,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
+        secret="YBiYJrmF5ufiTLdV1iDf",
+        pseudonymization_id="JKLM",
+        canceled=True,
+        positionid=2,
+    )
+    op.print_logs.create(
+        device=device,
+        type="badge",
+        source="pretixpos",
+        info={"cashier": 1234},
+        datetime=datetime.datetime(2017, 12, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+    )
+    op.answers.create(question=question, answer='S')
+    return o
 
 
 @pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
 def order2(event2, item2):
-    testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        o = Order.objects.create(
-            code='BAR', event=event2, email='dummy@dummy.test',
-            status=Order.STATUS_PENDING, secret="asd436cvbfd1",
-            datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
-            sales_channel=event2.organizer.sales_channels.get(identifier="web"),
-            total=23, locale='en'
-        )
-        o.payments.create(
-            provider='banktransfer',
-            state='pending',
-            amount=Decimal('23.00'),
-        )
-        OrderPosition.objects.create(
-            order=o,
-            item=item2,
-            variation=None,
-            price=Decimal("23"),
-            attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
-            secret="asdlfksdgdfgxcbfgdhfg",
-            pseudonymization_id="AC892345",
-            positionid=1,
-        )
-        return o
+    o = Order.objects.create(
+        code='BAR', event=event2, email='dummy@dummy.test',
+        status=Order.STATUS_PENDING, secret="asd436cvbfd1",
+        datetime=datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        expires=datetime.datetime(2017, 12, 10, 10, 0, 0, tzinfo=datetime.timezone.utc),
+        sales_channel=event2.organizer.sales_channels.get(identifier="web"),
+        total=23, locale='en'
+    )
+    o.payments.create(
+        provider='banktransfer',
+        state='pending',
+        amount=Decimal('23.00'),
+    )
+    OrderPosition.objects.create(
+        order=o,
+        item=item2,
+        variation=None,
+        price=Decimal("23"),
+        attendee_name_parts={"full_name": "Peter", "_scheme": "full"},
+        secret="asdlfksdgdfgxcbfgdhfg",
+        pseudonymization_id="AC892345",
+        positionid=1,
+    )
+    return o
 
 
 TEST_ORDERPOSITION_RES = {

--- a/src/tests/api/test_subevents.py
+++ b/src/tests/api/test_subevents.py
@@ -26,6 +26,7 @@ from unittest import mock
 import pytest
 from django_countries.fields import Country
 from django_scopes import scopes_disabled
+from freezegun import freeze_time
 
 from pretix.base.models import (
     InvoiceAddress, ItemVariation, Order, OrderPosition, SeatingPlan, SubEvent,
@@ -50,23 +51,20 @@ def variations2(item2):
 
 
 @pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
 def order(event, item, taxrule):
-    testtime = datetime(2017, 12, 1, 10, 0, 0, tzinfo=timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        o = Order.objects.create(
-            code='FOO', event=event, email='dummy@dummy.test',
-            status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
-            datetime=datetime(2017, 12, 1, 10, 0, 0, tzinfo=timezone.utc),
-            expires=datetime(2017, 12, 10, 10, 0, 0, tzinfo=timezone.utc),
-            sales_channel=event.organizer.sales_channels.get(identifier="web"),
-            total=23, locale='en'
-        )
-        o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
-                      tax_value=Decimal('0.05'), tax_rule=taxrule)
-        InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'))
-        return o
+    o = Order.objects.create(
+        code='FOO', event=event, email='dummy@dummy.test',
+        status=Order.STATUS_PENDING, secret="k24fiuwvu8kxz3y1",
+        datetime=datetime(2017, 12, 1, 10, 0, 0, tzinfo=timezone.utc),
+        expires=datetime(2017, 12, 10, 10, 0, 0, tzinfo=timezone.utc),
+        sales_channel=event.organizer.sales_channels.get(identifier="web"),
+        total=23, locale='en'
+    )
+    o.fees.create(fee_type=OrderFee.FEE_TYPE_PAYMENT, value=Decimal('0.25'), tax_rate=Decimal('19.00'),
+                  tax_value=Decimal('0.05'), tax_rule=taxrule)
+    InvoiceAddress.objects.create(order=o, company="Sample company", country=Country('NZ'))
+    return o
 
 
 @pytest.fixture

--- a/src/tests/api/test_waitinglist.py
+++ b/src/tests/api/test_waitinglist.py
@@ -25,6 +25,7 @@ from unittest import mock
 
 import pytest
 from django_scopes import scopes_disabled
+from freezegun import freeze_time
 
 from pretix.base.models import WaitingListEntry
 
@@ -42,12 +43,9 @@ def quota(event, item):
 
 
 @pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
 def wle(event, item):
-    testtime = datetime.datetime(2017, 12, 1, 10, 0, 0, tzinfo=datetime.timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        return WaitingListEntry.objects.create(event=event, item=item, email="waiting@example.org", locale="en")
+    return WaitingListEntry.objects.create(event=event, item=item, email="waiting@example.org", locale="en")
 
 
 TEST_WLE_RES = {

--- a/src/tests/plugins/banktransfer/test_api.py
+++ b/src/tests/plugins/banktransfer/test_api.py
@@ -27,6 +27,7 @@ from unittest import mock
 import pytest
 from django.utils.timezone import now
 from django_scopes import scopes_disabled
+from freezegun import freeze_time
 
 from pretix.base.models import (
     Event, Item, Order, OrderPosition, Organizer, Quota, Team, User,
@@ -92,15 +93,13 @@ RES_JOB = {
 
 
 @pytest.mark.django_db
+@freeze_time("2017-12-01 10:00:00+00:00")
 def test_api_list(env, client):
     testtime = datetime(2017, 12, 1, 10, 0, 0, tzinfo=timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        job = BankImportJob.objects.create(event=env[0], organizer=env[0].organizer, currency='EUR')
-        BankTransaction.objects.create(event=env[0], import_job=job, payer='Foo',
-                                       state=BankTransaction.STATE_ERROR,
-                                       amount=0, date='unknown', currency='EUR')
+    job = BankImportJob.objects.create(event=env[0], organizer=env[0].organizer, currency='EUR')
+    BankTransaction.objects.create(event=env[0], import_job=job, payer='Foo',
+                                   state=BankTransaction.STATE_ERROR,
+                                   amount=0, date='unknown', currency='EUR')
     res = copy.copy(RES_JOB)
     res['id'] = job.pk
     res['created'] = testtime.isoformat().replace('+00:00', 'Z')
@@ -112,15 +111,13 @@ def test_api_list(env, client):
 
 
 @pytest.mark.django_db
+@freeze_time("2017-12-01 10:00:00+00:00")
 def test_api_detail(env, client):
     testtime = datetime(2017, 12, 1, 10, 0, 0, tzinfo=timezone.utc)
-
-    with mock.patch('django.utils.timezone.now') as mock_now:
-        mock_now.return_value = testtime
-        job = BankImportJob.objects.create(event=env[0], organizer=env[0].organizer, currency='EUR')
-        BankTransaction.objects.create(event=env[0], import_job=job, payer='Foo',
-                                       state=BankTransaction.STATE_ERROR,
-                                       amount=0, date='unknown', currency='EUR')
+    job = BankImportJob.objects.create(event=env[0], organizer=env[0].organizer, currency='EUR')
+    BankTransaction.objects.create(event=env[0], import_job=job, payer='Foo',
+                                   state=BankTransaction.STATE_ERROR,
+                                   amount=0, date='unknown', currency='EUR')
     res = copy.copy(RES_JOB)
     res['id'] = job.pk
     res['created'] = testtime.isoformat().replace('+00:00', 'Z')


### PR DESCRIPTION
## Summary
Replace \mock.patch('django.utils.timezone.now')\ context-manager blocks in test fixtures with the \@freeze_time\ decorator from the \reezegun\ library.

Files changed: test_cart, test_checkin, test_checkinrpc, test_events, test_invoices, test_items, test_order_change, test_order_create, test_orders, test_subevents, test_waitinglist, and banktransfer/test_api.

## Why
\@freeze_time\ is declarative and avoids nested \with mock.patch(...)\ boilerplate in fixtures.

## Test instructions
\\\
cd src
pytest tests/api/ -v
\\\
All 1553 tests in tests/api/ pass.

## Self-review
See \docs/reviews/PR-2-self-review.md\

Closes #2