### PR TITLE
Add TESTING.md with testing strategy, commands, and conventions

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,104 @@
+# Testing Strategy
+
+## Overview
+
+This document describes the testing approach for the pretix project, including test structure, execution commands, and conventions.
+
+---
+
+## Test Structure
+
+```
+src/tests/
+├── api/            # REST API endpoint tests
+├── control/        # Admin/control panel tests
+├── base/           # Core model and business logic tests
+└── plugins/        # Plugin-specific tests (banktransfer, stripe, etc.)
+```
+
+Each test module follows Django's pytest integration (`pytest-django`).
+
+---
+
+## Running Tests
+
+### Full test suite
+
+```bash
+# From the src/ directory with your virtualenv active
+pytest
+```
+
+### API tests only
+
+```bash
+pytest tests/api/ -v
+```
+
+### Run a single test file
+
+```bash
+pytest tests/api/test_orders.py -v
+```
+
+### Run tests matching a keyword
+
+```bash
+pytest -k "test_order_create" -v
+```
+
+### Fast run (parallel workers)
+
+```bash
+pytest -n auto
+```
+
+---
+
+## Key Conventions
+
+### Deterministic time
+
+All tests that depend on the current time freeze the clock using `freezegun`:
+
+```python
+from freezegun import freeze_time
+
+@pytest.fixture
+@freeze_time("2017-12-01 10:00:00+00:00")
+def order(event, item):
+    ...
+```
+
+Never use `mock.patch('django.utils.timezone.now')` in new tests — prefer `@freeze_time`.
+
+### Database isolation
+
+Each test gets a clean database via `@pytest.mark.django_db`. Shared state is created through pytest fixtures, not module-level setup.
+
+### Scope isolation
+
+Use `django_scopes.scopes_disabled()` in tests that need to query across organizer scopes:
+
+```python
+with scopes_disabled():
+    order = Order.objects.get(code="FOO")
+```
+
+---
+
+## CI / GitHub Actions
+
+Tests run automatically on every pull request via `.github/workflows/`.  
+A PR must be green before merging.
+
+---
+
+## Coverage
+
+To generate a coverage report:
+
+```bash
+pytest --cov=pretix --cov-report=html
+open htmlcov/index.html
+```

--- a/docs/reviews/PR-4-self-review.md
+++ b/docs/reviews/PR-4-self-review.md
@@ -1,0 +1,26 @@
+# PR Self-Review: Document Testing Strategy and Commands
+
+## What changed?
+
+Added `docs/TESTING.md` — a new reference document that describes:
+
+- The overall test directory structure
+- Commands to run the full test suite, API tests, a single file, keyword-filtered tests, and parallel tests
+- The `@freeze_time` convention for deterministic time in tests
+- The `django_scopes.scopes_disabled()` convention for cross-scope queries
+- CI/GitHub Actions integration note
+- Coverage report generation
+
+## Why this layer?
+
+Documentation lives outside the test runner itself, making it easy for new contributors to discover how to run tests without digging through `setup.cfg` or CI configs.
+
+## Risks
+
+None — this is a docs-only change, no production or test code was modified.
+
+## Missing coverage
+
+The document covers the main test categories but does not enumerate every plugin's bespoke test helpers. Those can be added incrementally.
+
+Closes #4


### PR DESCRIPTION
## Summary
Added \docs/TESTING.md\  a reference document describing the test structure, pytest commands, and key testing conventions (freeze_time, scopes_disabled).

## Why
New contributors need a single place to understand how to run tests without digging through CI configs.

## Changes
- \docs/TESTING.md\  new testing strategy doc
- \docs/reviews/PR-4-self-review.md\  self-review notes

No production code or test logic was changed.

Closes #4