### PR TITLE
Add regression tests for order API edge cases

### DIFF
--- a/docs/reviews/PR-3-self-review.md
+++ b/docs/reviews/PR-3-self-review.md
@@ -1,0 +1,33 @@
+# PR Self-Review: Add API Tests for Order Edge Cases
+
+## What changed?
+
+Added 4 new regression tests to `src/tests/api/test_orders.py`:
+
+| Test | Scenario |
+|---|---|
+| `test_order_cancel_already_canceled_returns_400` | Canceling a previously canceled order must return 400 |
+| `test_order_refund_exceeds_paid_amount_returns_400` | A refund larger than the paid amount must be rejected with 400 |
+| `test_order_mark_paid_twice_returns_400` | Marking an already-paid order as paid again must return 400 |
+| `test_order_list_filter_by_status` | `?status=n` must only return pending orders; `?status=p` only paid ones |
+
+## Why this test layer?
+
+These are API-level tests that exercise the HTTP layer and Django REST framework serializers/views. They guard against off-by-one guard conditions that are easy to miss at the unit level.
+
+## Risks
+
+No production code was changed; tests only.
+
+## Test evidence
+
+```
+pytest tests/api/test_orders.py -k "test_order_cancel_already_canceled or test_order_refund_exceeds or test_order_mark_paid_twice or test_order_list_filter_by_status" -v
+4 passed
+```
+
+## Missing coverage
+
+- Concurrent locking / race-condition scenarios require a multi-threaded test setup not available in the current CI environment.
+
+Closes #3

--- a/src/tests/api/test_orders.py
+++ b/src/tests/api/test_orders.py
@@ -2037,3 +2037,96 @@ def test_pdf_data(token_client, organizer, event, order, django_assert_max_num_q
     ))
     assert resp.status_code == 200
     assert not resp.data.get('pdf_data')
+
+
+# ---------------------------------------------------------------------------
+# Edge-case regression tests (Issue #3)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_order_cancel_already_canceled_returns_400(token_client, organizer, event, order):
+    """Canceling an order that is already canceled must return HTTP 400, not 500."""
+    # First cancel legitimately
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/cancel/'.format(
+            organizer.slug, event.slug, order.code
+        ),
+        data={}, format='json'
+    )
+    assert resp.status_code == 200
+    with scopes_disabled():
+        order.refresh_from_db()
+    assert order.status == Order.STATUS_CANCELED
+
+    # Try to cancel again — should be rejected
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/cancel/'.format(
+            organizer.slug, event.slug, order.code
+        ),
+        data={}, format='json'
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_order_refund_exceeds_paid_amount_returns_400(token_client, organizer, event, order):
+    """Creating a refund larger than what was paid must return HTTP 400."""
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/refunds/'.format(
+            organizer.slug, event.slug, order.code
+        ),
+        data={
+            'payment': None,
+            'provider': 'banktransfer',
+            'amount': '9999.00',
+            'mark_canceled': False,
+        },
+        format='json'
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_order_mark_paid_twice_returns_400(token_client, organizer, event, order):
+    """Marking a pending order as paid twice must not succeed on the second attempt."""
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/mark_paid/'.format(
+            organizer.slug, event.slug, order.code
+        ),
+        data={}, format='json'
+    )
+    assert resp.status_code == 200
+    with scopes_disabled():
+        order.refresh_from_db()
+    assert order.status == Order.STATUS_PAID
+
+    # Mark paid again
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/{}/mark_paid/'.format(
+            organizer.slug, event.slug, order.code
+        ),
+        data={}, format='json'
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_order_list_filter_by_status(token_client, organizer, event, order):
+    """Order list filtered by status=n must only return PENDING orders."""
+    with scopes_disabled():
+        order.status = Order.STATUS_PAID
+        order.save()
+
+    resp = token_client.get(
+        '/api/v1/organizers/{}/events/{}/orders/?status=n'.format(organizer.slug, event.slug)
+    )
+    assert resp.status_code == 200
+    # no pending orders exist — list must be empty
+    assert resp.data['count'] == 0
+
+    resp = token_client.get(
+        '/api/v1/organizers/{}/events/{}/orders/?status=p'.format(organizer.slug, event.slug)
+    )
+    assert resp.status_code == 200
+    assert resp.data['count'] == 1
+    assert resp.data['results'][0]['code'] == order.code


### PR DESCRIPTION
## Summary
Added 4 new regression tests to \	ests/api/test_orders.py\ covering under-tested edge cases:

- **Cancel-already-canceled**: canceling a canceled order returns 400
- **Refund-exceeds-paid**: a refund larger than paid amount returns 400
- **Double mark-paid**: marking an already-paid order as paid again returns 400
- **Status filter**: \?status=n\ and \?status=p\ return only orders of the correct status

## Test instructions
\\\
pytest tests/api/test_orders.py -k 'test_order_cancel_already_canceled or test_order_refund_exceeds or test_order_mark_paid_twice or test_order_list_filter_by_status' -v
\\\
All 4 pass.

## Self-review
See \docs/reviews/PR-3-self-review.md\

Closes #3