### PR TITLE
Fix CI: remove unused mock imports and add docs rule to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include README.rst
 include src/Makefile
+recursive-include docs *.md
 include _build/backend.py
 global-include *.proto
 recursive-include src/pretix/static *

--- a/src/tests/api/test_cart.py
+++ b/src/tests/api/test_cart.py
@@ -22,7 +22,6 @@
 import copy
 import datetime
 from decimal import Decimal
-from unittest import mock
 
 import pytest
 from django.core.files.base import ContentFile

--- a/src/tests/api/test_checkinrpc.py
+++ b/src/tests/api/test_checkinrpc.py
@@ -21,7 +21,6 @@
 #
 import datetime
 from decimal import Decimal
-from unittest import mock
 
 import pytest
 from django.core.files.base import ContentFile

--- a/src/tests/api/test_events.py
+++ b/src/tests/api/test_events.py
@@ -35,7 +35,6 @@
 import copy
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from unittest import mock
 
 import pytest
 from django.conf import settings

--- a/src/tests/api/test_invoices.py
+++ b/src/tests/api/test_invoices.py
@@ -21,7 +21,6 @@
 #
 import datetime
 from decimal import Decimal
-from unittest import mock
 
 import freezegun
 import pytest

--- a/src/tests/api/test_items.py
+++ b/src/tests/api/test_items.py
@@ -35,7 +35,6 @@ import os
 import time
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from unittest import mock
 
 import pytest
 from django.conf import settings

--- a/src/tests/api/test_order_change.py
+++ b/src/tests/api/test_order_change.py
@@ -22,7 +22,6 @@
 import datetime
 import json
 from decimal import Decimal
-from unittest import mock
 
 import pytest
 from django.core import mail as djmail

--- a/src/tests/api/test_order_create.py
+++ b/src/tests/api/test_order_create.py
@@ -23,7 +23,6 @@ import copy
 import datetime
 import json
 from decimal import Decimal
-from unittest import mock
 
 import pytest
 from django.conf import settings

--- a/src/tests/api/test_orders.py
+++ b/src/tests/api/test_orders.py
@@ -23,7 +23,6 @@ import copy
 import datetime
 import json
 from decimal import Decimal
-from unittest import mock
 
 import pytest
 from django.core import mail as djmail

--- a/src/tests/plugins/banktransfer/test_api.py
+++ b/src/tests/plugins/banktransfer/test_api.py
@@ -22,7 +22,6 @@
 import copy
 import json
 from datetime import datetime, timedelta, timezone
-from unittest import mock
 
 import pytest
 from django.utils.timezone import now


### PR DESCRIPTION
Follow-up to the freeze_time refactor. Three CI issues:

1. **flake8 F401**: \rom unittest import mock\ was left in 9 test files after all \mock.patch\ calls were replaced by \@freeze_time\. Removed the import from each file.
2. **check-manifest**: \docs/reviews/PR-2-self-review.md\ was missing from sdist. Added \ecursive-include docs *.md\ to \MANIFEST.in\.
3. **licenseheaders**: Already resolved  \	est_exporter.py\ now has the header in master.

No test logic changed.