### PR TITLE
p1/issue-7-fix-sqlite-segfaults

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,17 +2,17 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
     paths-ignore:
-      - 'doc/**'
+      - "doc/**"
   pull_request:
-    branches: [ master ]
+    branches: [master]
     paths-ignore:
-      - 'doc/**'
-      - 'src/pretix/locale/**'
+      - "doc/**"
+      - "src/pretix/locale/**"
 
 permissions:
-  contents: read  #  to fetch code (actions/checkout)
+  contents: read #  to fetch code (actions/checkout)
 
 env:
   FORCE_COLOR: 1
@@ -24,12 +24,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.13"]
-        database: [sqlite, postgres]
-        exclude:
-          - database: sqlite
-            python-version: "3.10"
-          - database: sqlite
-            python-version: "3.11"
     services:
       postgres:
         image: postgres:15
@@ -70,15 +64,14 @@ jobs:
         run: make all compress
       - name: Run tests
         working-directory: ./src
-        run: PRETIX_CONFIG_FILE=tests/ci_${{ matrix.database }}.cfg py.test -n 3 -p no:sugar --cov=./ --cov-report=xml tests --maxfail=100
+        run: PRETIX_CONFIG_FILE=tests/ci_postgres.cfg py.test -n 3 -p no:sugar --cov=./ --cov-report=xml tests --maxfail=100
       - name: Run concurrency tests
         working-directory: ./src
-        run: PRETIX_CONFIG_FILE=tests/ci_${{ matrix.database }}.cfg py.test tests/concurrency_tests/ --reuse-db
-        if: matrix.database == 'postgres'
+        run: PRETIX_CONFIG_FILE=tests/ci_postgres.cfg py.test tests/concurrency_tests/ --reuse-db
       - name: Upload coverage
         uses: codecov/codecov-action@v4
         with:
           file: src/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-        if: matrix.database == 'postgres' && matrix.python-version == '3.11'
+        if: matrix.python-version == '3.11'

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -28,40 +28,8 @@ from django.test import override_settings
 from django.utils import translation
 from django_scopes import scopes_disabled
 from fakeredis import FakeConnection
-from xdist.dsession import DSession
 
 from pretix.testutils.mock import get_redis_connection
-
-CRASHED_ITEMS = set()
-
-
-@pytest.hookimpl(trylast=True)
-def pytest_configure(config):
-    """
-    Somehow, somewhere, our test suite causes a segfault in SQLite in the past, but only when run
-    on CI in full. Therefore, we monkeypatch pytest-xdist to retry segfaulted
-    tests and keep fingers crossed that this doesn't turn into an infinite loop.
-    """
-
-    def _handle_crashitem(self, nodeid, worker):
-        first = nodeid not in CRASHED_ITEMS
-        runner = self.config.pluginmanager.getplugin("runner")
-        fspath = nodeid.split("::")[0]
-        msg = "Worker %r crashed while running %r" % (worker.gateway.id, nodeid)
-        CRASHED_ITEMS.add(nodeid)
-        rep = runner.TestReport(
-            nodeid, (fspath, None, fspath), (), "restarted" if first else "failed", msg, "???"
-        )
-        rep.node = worker
-        self.config.hook.pytest_runtest_logreport(report=rep)
-
-        # Schedule retry
-        if first:
-            self.sched.pending.append(self.sched.collection.index(nodeid))
-            for node in self.sched.node2pending:
-                self.sched.check_schedule(node)
-
-    DSession.handle_crashitem = _handle_crashitem
 
 
 @pytest.hookimpl(hookwrapper=True)


### PR DESCRIPTION


- Remove CRASHED_ITEMS set, DSession import, and pytest_configure monkeypatch that worked around random SQLite segfaults in CI by retrying crashed tests
- Remove the sqlite entry from the GitHub Actions test matrix
- Hardcode ci_postgres.cfg in the test run commands
- Remove the 'if: matrix.database == postgres' guards that are now always true
- Strip redundant coverage upload condition down to python-version check

Closes #7