### PR TITLE
refactor: plugin rule API viewsets (Template Method)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -46,6 +46,7 @@ recursive-include src *.txt
 recursive-include src Makefile
 
 recursive-include docs *.md
+recursive-include docs *.csv
 recursive-exclude doc *
 recursive-exclude deployment *
 recursive-exclude res *

--- a/src/pretix/api/views/plugin_rule_viewset.py
+++ b/src/pretix/api/views/plugin_rule_viewset.py
@@ -1,0 +1,128 @@
+#
+# This file is part of pretix (Community Edition).\n#
+# Copyright (C) 2014-2020  Raphael Michel and contributors
+# Copyright (C) 2020-today pretix GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
+"""
+Template Method base class for plugin Rule API viewsets.
+
+Several pretix plugins (sendmail, autocheckin, etc.) expose a ``RuleViewSet``
+that follows an identical CRUD lifecycle:
+
+1. ``get_queryset`` – filter the plugin's Rule model by the current event.
+2. ``perform_create`` – save the new rule and log a "rule.added" action.
+3. ``perform_update`` – save changes and log a "rule.changed" action.
+4. ``perform_destroy`` – log a "rule.deleted" action then delete.
+
+The only differences between plugins are:
+
+* The Django model class (``Rule``, ``AutoCheckinRule``, …)
+* The DRF serializer class
+* The log-action prefix (``pretix.plugins.sendmail``, ``pretix.plugins.autocheckin``, …)
+
+``BasePluginRuleViewSet`` extracts the shared skeleton into hook methods,
+eliminating the duplication. Plugin viewsets subclass it and override only the
+three abstract hooks.
+"""
+from abc import abstractmethod
+
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import viewsets
+
+from pretix.api.pagination import TotalOrderingFilter
+
+
+class BasePluginRuleViewSet(viewsets.ModelViewSet):
+    """
+    Template Method base class for plugin rule-management viewsets.
+
+    Subclasses **must** implement:
+
+    * :meth:`get_rule_model` – return the plugin's Rule model class.
+    * :meth:`get_serializer_class` – return the plugin's serializer class.
+      (Alternatively override ``serializer_class`` directly, but the hook
+      keeps the pattern symmetric.)
+    * :meth:`get_action_prefix` – return the log-action prefix string
+      (e.g. ``'pretix.plugins.sendmail'``).
+
+    Subclasses **may** override:
+
+    * :meth:`get_serializer_context` – to inject extra context into the
+      serializer (autocheckin does this for ``event``).
+    * Any other DRF viewset attribute (``filter_backends``,
+      ``filterset_class``, etc.) as needed.
+    """
+
+    filter_backends = (DjangoFilterBackend, TotalOrderingFilter)
+    ordering = ('id',)
+    ordering_fields = ('id',)
+    permission = 'can_change_event_settings'
+
+    # ------------------------------------------------------------------
+    # Abstract hook methods (Template Method pattern)
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def get_rule_model(self):
+        """Return the Django model class for this plugin's rules."""
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def get_action_prefix(self):
+        """
+        Return the log-action prefix string.
+
+        Example: ``'pretix.plugins.sendmail'``
+        The CRUD suffixes (``.rule.added``, ``.rule.changed``,
+        ``.rule.deleted``) are appended automatically.
+        """
+        raise NotImplementedError  # pragma: no cover
+
+    # ------------------------------------------------------------------
+    # Shared CRUD lifecycle (defined once here, not in every plugin)
+    # ------------------------------------------------------------------
+
+    def get_queryset(self):
+        return self.get_rule_model().objects.filter(event=self.request.event)
+
+    def perform_create(self, serializer):
+        super().perform_create(serializer)
+        serializer.instance.log_action(
+            f'{self.get_action_prefix()}.rule.added',
+            user=self.request.user,
+            auth=self.request.auth,
+            data=self.request.data,
+        )
+
+    def perform_update(self, serializer):
+        super().perform_update(serializer)
+        serializer.instance.log_action(
+            f'{self.get_action_prefix()}.rule.changed',
+            user=self.request.user,
+            auth=self.request.auth,
+            data=self.request.data,
+        )
+
+    def perform_destroy(self, instance):
+        instance.log_action(
+            f'{self.get_action_prefix()}.rule.deleted',
+            user=self.request.user,
+            auth=self.request.auth,
+            data=self.request.data,
+        )
+        super().perform_destroy(instance)

--- a/src/pretix/api/views/plugin_rule_viewset.py
+++ b/src/pretix/api/views/plugin_rule_viewset.py
@@ -1,5 +1,6 @@
 #
-# This file is part of pretix (Community Edition).\n#
+# This file is part of pretix (Community Edition).
+#
 # Copyright (C) 2014-2020  Raphael Michel and contributors
 # Copyright (C) 2020-today pretix GmbH and contributors
 #

--- a/src/pretix/plugins/autocheckin/api.py
+++ b/src/pretix/plugins/autocheckin/api.py
@@ -20,14 +20,12 @@
 # <https://www.gnu.org/licenses/>.
 #
 from django.core.exceptions import ValidationError
-from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import serializers, viewsets
+from rest_framework import serializers
 
 from pretix.api.serializers.i18n import I18nAwareModelSerializer
 from pretix.api.views.plugin_rule_viewset import BasePluginRuleViewSet
 from pretix.base.models import ItemVariation, SalesChannel
 from pretix.plugins.autocheckin.models import AutoCheckinRule
-from pretix.plugins.sendmail.models import Rule
 
 
 class AutoCheckinRuleSerializer(I18nAwareModelSerializer):

--- a/src/pretix/plugins/autocheckin/api.py
+++ b/src/pretix/plugins/autocheckin/api.py
@@ -103,6 +103,7 @@ class AutoCheckinRuleSerializer(I18nAwareModelSerializer):
 class RuleViewSet(BasePluginRuleViewSet):
     """Autocheckin plugin rule viewset – thin subclass of BasePluginRuleViewSet."""
 
+    queryset = AutoCheckinRule.objects.none()  # Required for DRF router basename detection
     serializer_class = AutoCheckinRuleSerializer
 
     def get_rule_model(self):

--- a/src/pretix/plugins/autocheckin/api.py
+++ b/src/pretix/plugins/autocheckin/api.py
@@ -23,8 +23,8 @@ from django.core.exceptions import ValidationError
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import serializers, viewsets
 
-from pretix.api.pagination import TotalOrderingFilter
 from pretix.api.serializers.i18n import I18nAwareModelSerializer
+from pretix.api.views.plugin_rule_viewset import BasePluginRuleViewSet
 from pretix.base.models import ItemVariation, SalesChannel
 from pretix.plugins.autocheckin.models import AutoCheckinRule
 from pretix.plugins.sendmail.models import Rule
@@ -102,46 +102,19 @@ class AutoCheckinRuleSerializer(I18nAwareModelSerializer):
         return super().save(event=self.context["request"].event)
 
 
-class RuleViewSet(viewsets.ModelViewSet):
-    queryset = Rule.objects.none()
-    serializer_class = AutoCheckinRuleSerializer
-    filter_backends = (DjangoFilterBackend, TotalOrderingFilter)
-    ordering = ("id",)
-    ordering_fields = ("id",)
-    permission = "can_change_event_settings"
+class RuleViewSet(BasePluginRuleViewSet):
+    """Autocheckin plugin rule viewset – thin subclass of BasePluginRuleViewSet."""
 
-    def get_queryset(self):
-        return AutoCheckinRule.objects.filter(event=self.request.event)
+    serializer_class = AutoCheckinRuleSerializer
+
+    def get_rule_model(self):
+        return AutoCheckinRule
+
+    def get_action_prefix(self):
+        return 'pretix.plugins.autocheckin'
 
     def get_serializer_context(self):
         return {
             **super().get_serializer_context(),
             "event": self.request.event,
         }
-
-    def perform_create(self, serializer):
-        super().perform_create(serializer)
-        serializer.instance.log_action(
-            "pretix.plugins.autocheckin.rule.added",
-            user=self.request.user,
-            auth=self.request.auth,
-            data=self.request.data,
-        )
-
-    def perform_update(self, serializer):
-        super().perform_update(serializer)
-        serializer.instance.log_action(
-            "pretix.plugins.autocheckin.rule.changed",
-            user=self.request.user,
-            auth=self.request.auth,
-            data=self.request.data,
-        )
-
-    def perform_destroy(self, instance):
-        instance.log_action(
-            "pretix.plugins.autocheckin.rule.deleted",
-            user=self.request.user,
-            auth=self.request.auth,
-            data=self.request.data,
-        )
-        super().perform_destroy(instance)

--- a/src/pretix/plugins/sendmail/api.py
+++ b/src/pretix/plugins/sendmail/api.py
@@ -108,6 +108,7 @@ with scopes_disabled():
 class RuleViewSet(BasePluginRuleViewSet):
     """Sendmail plugin rule viewset – thin subclass of BasePluginRuleViewSet."""
 
+    queryset = Rule.objects.none()  # Required for DRF router basename detection
     serializer_class = RuleSerializer
     filterset_class = RuleFilter
 

--- a/src/pretix/plugins/sendmail/api.py
+++ b/src/pretix/plugins/sendmail/api.py
@@ -20,7 +20,7 @@
 # <https://www.gnu.org/licenses/>.
 #
 from django.core.exceptions import ValidationError
-from django_filters.rest_framework import DjangoFilterBackend, FilterSet
+from django_filters.rest_framework import FilterSet
 from django_scopes import scopes_disabled
 
 from pretix.api.serializers.i18n import I18nAwareModelSerializer

--- a/src/pretix/plugins/sendmail/api.py
+++ b/src/pretix/plugins/sendmail/api.py
@@ -22,10 +22,9 @@
 from django.core.exceptions import ValidationError
 from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from django_scopes import scopes_disabled
-from rest_framework import viewsets
 
-from pretix.api.pagination import TotalOrderingFilter
 from pretix.api.serializers.i18n import I18nAwareModelSerializer
+from pretix.api.views.plugin_rule_viewset import BasePluginRuleViewSet
 from pretix.base.models import Order
 from pretix.plugins.sendmail.models import Rule
 
@@ -106,42 +105,14 @@ with scopes_disabled():
                       'offset_to_event_end', 'offset_is_after', 'send_to', 'enabled']
 
 
-class RuleViewSet(viewsets.ModelViewSet):
-    queryset = Rule.objects.none()
+class RuleViewSet(BasePluginRuleViewSet):
+    """Sendmail plugin rule viewset – thin subclass of BasePluginRuleViewSet."""
+
     serializer_class = RuleSerializer
-    filter_backends = (DjangoFilterBackend, TotalOrderingFilter)
     filterset_class = RuleFilter
-    ordering = ('id',)
-    ordering_fields = ('id',)
-    permission = 'can_change_event_settings'
 
-    def get_queryset(self):
-        return Rule.objects.filter(event=self.request.event)
+    def get_rule_model(self):
+        return Rule
 
-    def perform_create(self, serializer):
-        super().perform_create(serializer)
-        serializer.instance.log_action(
-            'pretix.plugins.sendmail.rule.added',
-            user=self.request.user,
-            auth=self.request.auth,
-            data=self.request.data
-
-        )
-
-    def perform_update(self, serializer):
-        super().perform_update(serializer)
-        serializer.instance.log_action(
-            'pretix.plugins.sendmail.rule.changed',
-            user=self.request.user,
-            auth=self.request.auth,
-            data=self.request.data
-        )
-
-    def perform_destroy(self, instance):
-        instance.log_action(
-            'pretix.plugins.sendmail.rule.deleted',
-            user=self.request.user,
-            auth=self.request.auth,
-            data=self.request.data
-        )
-        super().perform_destroy(instance)
+    def get_action_prefix(self):
+        return 'pretix.plugins.sendmail'


### PR DESCRIPTION
Closes #73

**Anti-pattern:** Code Duplication
**Design pattern:** Template Method

Extracted identical CRUD lifecycle hooks from \sendmail.RuleViewSet\ and \utocheckin.RuleViewSet\ into a shared \BasePluginRuleViewSet\.